### PR TITLE
[TASK] Remove intersphinx dependency

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -145,21 +145,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.intersphinx',
 ]
-#   'sphinx.ext.viewcode',
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('http://docs.python.org/', None),
-                       'osloconfig': ('http://docs.openstack.org/developer/oslo.config/', None),
-                       'pbr': ('http://docs.openstack.org/developer/pbr/', None),
-                       'rarfile': ('https://rarfile.readthedocs.org/en/latest/', None),
-                       'six': ('http://pythonhosted.org/six/', None),
-                       'sqlalchemy': ('http://docs.sqlalchemy.org/en/latest/',
-                                      None),
-                       'stevedore': ('http://stevedore.readthedocs.org/en/latest/', None),
-                       'xworkflows': ('http://xworkflows.readthedocs.org/en/latest/', None),
-                       }
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Remove intersphinx from the docs build as it triggers network calls that
occasionally fail, and we don't really use intersphinx (links other
sphinx documents out on the internet)

This also removes the requirement for internet access during docs build.

This causes docs jobs to fail because we error out on warnings.

Implements: 6
