### PR TITLE
[TASK] Switch to oslo_config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr
 twine
 
 futures
-oslo.config
+oslo.config>=1.9.0
 lockfile
 rarfile>=2.6
 six>=1.4.1

--- a/seedbox/cli.py
+++ b/seedbox/cli.py
@@ -11,7 +11,7 @@ import sys
 
 import lockfile
 from lockfile import pidlockfile
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox import db
 from seedbox import logext as logmgr

--- a/seedbox/db/__init__.py
+++ b/seedbox/db/__init__.py
@@ -1,7 +1,7 @@
 """Provides access to database API for interacting with the torrent data."""
 import logging
 
-from oslo.config import cfg
+from oslo_config import cfg
 import six.moves.urllib.parse as urlparse
 from stevedore import driver
 
@@ -38,7 +38,7 @@ def _get_connection(conf):
 def dbapi(conf=cfg.CONF):
     """Retrieves an instance of the configured database API.
 
-    :param oslo.config.cfg.ConfigOpts conf: an instance of the configuration
+    :param oslo_config.cfg.ConfigOpts conf: an instance of the configuration
                                             file
     :return: database API instance
     :rtype: :class:`~seedbox.db.api.DBApi`
@@ -52,9 +52,9 @@ def dbapi(conf=cfg.CONF):
 
 
 def list_opts():
-    """Returns a list of oslo.config options available in the library.
+    """Returns a list of oslo_config options available in the library.
 
-    The returned list includes all oslo.config options which may be registered
+    The returned list includes all oslo_config options which may be registered
     at runtime by the library.
 
     Each element of the list is a tuple. The first element is the name of the

--- a/seedbox/db/admin.py
+++ b/seedbox/db/admin.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 import click
-from oslo.config import cfg
+from oslo_config import cfg
 from passlib.hash import sha256_crypt
 import sandman
 from sandman import model

--- a/seedbox/db/base.py
+++ b/seedbox/db/base.py
@@ -12,7 +12,7 @@ class Connection(object):
         """Initializes new instance.
 
         :param conf: an instance of configuration file
-        :type conf: oslo.config.cfg.ConfigOpts
+        :type conf: oslo_config.cfg.ConfigOpts
         """
         self.conf = conf
 

--- a/seedbox/db/maintenance.py
+++ b/seedbox/db/maintenance.py
@@ -13,7 +13,7 @@ MAX_BACKUP_COUNT = 8
 def backup(conf):
     """create a backup copy of the database file.
 
-    :param oslo.config.cfg.ConfigOpts conf: an instance of configuration
+    :param oslo_config.cfg.ConfigOpts conf: an instance of configuration
     """
 
     LOG.debug('starting database backup process')

--- a/seedbox/db/sqlalchemy/api.py
+++ b/seedbox/db/sqlalchemy/api.py
@@ -18,7 +18,7 @@ class Connection(base.Connection):
         """Initialize new instance.
 
         :param conf: an instance of configuration file
-        :type conf: oslo.config.cfg.ConfigOpts
+        :type conf: oslo_config.cfg.ConfigOpts
         """
         super(Connection, self).__init__(conf)
         self._engine_facade = db_session.EngineFacade.from_config(

--- a/seedbox/db/sqlalchemy/session.py
+++ b/seedbox/db/sqlalchemy/session.py
@@ -112,12 +112,12 @@ class EngineFacade(object):
 
     @classmethod
     def from_config(cls, connection_string, conf):
-        """Initialize EngineFacade using oslo.config config instance options.
+        """Initialize EngineFacade using oslo_config config instance options.
 
         :param connection_string: SQLAlchemy connection string
         :type connection_string: string
-        :param conf: oslo.config config instance
-        :type conf: oslo.config.cfg.ConfigOpts
+        :param conf: oslo_config config instance
+        :type conf: oslo_config.cfg.ConfigOpts
 
         """
         LOG.debug('making connection using connect string: %s',

--- a/seedbox/logext.py
+++ b/seedbox/logext.py
@@ -8,7 +8,7 @@ import logging.config
 import logging.handlers
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 import six
 
 if hasattr(logging, 'NullHandler'):

--- a/seedbox/options.py
+++ b/seedbox/options.py
@@ -6,7 +6,7 @@ manages loading all Options for system.
 import os
 import sys
 
-from oslo.config import cfg
+from oslo_config import cfg
 from six import moves
 
 from seedbox import version
@@ -106,9 +106,9 @@ def initialize(args):
 
 
 def list_opts():
-    """Returns a list of oslo.config options available in the library.
+    """Returns a list of oslo_config options available in the library.
 
-    The returned list includes all oslo.config options which may be registered
+    The returned list includes all oslo_config options which may be registered
     at runtime by the library.
 
     Each element of the list is a tuple. The first element is the name of the

--- a/seedbox/process/__init__.py
+++ b/seedbox/process/__init__.py
@@ -75,9 +75,9 @@ def start():
 
 
 def list_opts():
-    """Returns a list of oslo.config options available in the library.
+    """Returns a list of oslo_config options available in the library.
 
-    The returned list includes all oslo.config options which may be registered
+    The returned list includes all oslo_config options which may be registered
     at runtime by the library.
 
     Each element of the list is a tuple. The first element is the name of the

--- a/seedbox/process/flow.py
+++ b/seedbox/process/flow.py
@@ -5,7 +5,7 @@ plugins for each and updating the db cache after each step.
 """
 import logging
 
-from oslo.config import cfg
+from oslo_config import cfg
 from stevedore import named
 import xworkflows
 

--- a/seedbox/process/manager.py
+++ b/seedbox/process/manager.py
@@ -2,7 +2,7 @@
 import logging
 
 import concurrent.futures as conc_futures
-from oslo.config import cfg
+from oslo_config import cfg
 
 LOG = logging.getLogger(__name__)
 

--- a/seedbox/tasks/__init__.py
+++ b/seedbox/tasks/__init__.py
@@ -2,9 +2,9 @@
 
 
 def list_opts():
-    """Returns a list of oslo.config options available in the library.
+    """Returns a list of oslo_config options available in the library.
 
-    The returned list includes all oslo.config options which may be registered
+    The returned list includes all oslo_config options which may be registered
     at runtime by the library.
 
     Each element of the list is a tuple. The first element is the name of the

--- a/seedbox/tasks/base.py
+++ b/seedbox/tasks/base.py
@@ -7,7 +7,7 @@ import logging
 import os
 import traceback
 
-from oslo.config import cfg
+from oslo_config import cfg
 import six
 
 from seedbox.common import timeutil

--- a/seedbox/tasks/filecopy.py
+++ b/seedbox/tasks/filecopy.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox.tasks import base
 

--- a/seedbox/tasks/filedelete.py
+++ b/seedbox/tasks/filedelete.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox.tasks import base
 

--- a/seedbox/tasks/filesync.py
+++ b/seedbox/tasks/filesync.py
@@ -5,7 +5,7 @@ Performs rsync of a file to a specified location.
 import logging
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox.tasks import base
 from seedbox.tasks import subprocessext

--- a/seedbox/tasks/fileunrar.py
+++ b/seedbox/tasks/fileunrar.py
@@ -5,7 +5,7 @@ For decompressing archived files to specified location.
 import logging
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 import rarfile
 
 from seedbox.tasks import base

--- a/seedbox/tasks/subprocessext.py
+++ b/seedbox/tasks/subprocessext.py
@@ -29,7 +29,7 @@ import os
 import subprocess
 import time
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 LOG = logging.getLogger(__name__)
 

--- a/seedbox/tests/test.py
+++ b/seedbox/tests/test.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import tempfile
 
-from oslo.config import fixture as config
+from oslo_config import fixture as config
 from oslotest import base
 
 

--- a/seedbox/tests/test_options.py
+++ b/seedbox/tests/test_options.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import os
 
 import fixtures
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox import options
 from seedbox.tests import test

--- a/seedbox/torrent/__init__.py
+++ b/seedbox/torrent/__init__.py
@@ -1,4 +1,4 @@
-from oslo.config import cfg
+from oslo_config import cfg
 
 OPTS = [
     cfg.StrOpt('torrent_path',
@@ -36,9 +36,9 @@ def load():
 
 
 def list_opts():
-    """Returns a list of oslo.config options available in the library.
+    """Returns a list of oslo_config options available in the library.
 
-    The returned list includes all oslo.config options which may be registered
+    The returned list includes all oslo_config options which may be registered
     at runtime by the library.
 
     Each element of the list is a tuple. The first element is the name of the

--- a/seedbox/torrent/loader.py
+++ b/seedbox/torrent/loader.py
@@ -7,7 +7,7 @@ import glob
 import logging
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from seedbox.common import tools
 from seedbox import constants


### PR DESCRIPTION
oslo.config namespace has been deprecated and replaced by the
namespace oslo_config. All references to the old namespace
have now been replaced by the new namespace.

Implements: 16
closes #16